### PR TITLE
return all valid reports

### DIFF
--- a/info.go
+++ b/info.go
@@ -214,7 +214,10 @@ func (c *Client) GetEnclavesInfo(options *EnclaveInfoOptions) ([]*EnclaveInfo, [
 			reqErrors = append(reqErrors, err)
 		}
 
-		return nil, reqErrors
+		// all request have failed
+		if len(reqErrors) == numServices {
+			return nil, reqErrors
+		}
 	}
 
 	var info []*EnclaveInfo

--- a/notarize.go
+++ b/notarize.go
@@ -305,7 +305,7 @@ type AttestationResponse struct {
 	AttestationRequest *AttestationRequest `json:"attestationRequest"`
 }
 
-// Notarize requests attestation of data extracted from the provided URL using the provided selector. Attestation is created by one or more Trusted Execution Environments (TEE). If more than one is used, all attestation requests should succeed.
+// Notarize requests attestation of data extracted from the provided URL using the provided selector. Attestation is created by one or more Trusted Execution Environments (TEE). Returns all successfully produced and verified attestations and discards the invalid ones.
 //
 // It is highly recommended to use time insensitive historic data for notarization. In case of using live data, other people might see different results when requesting the same url with the same parameters.
 //
@@ -606,7 +606,10 @@ func (c *Client) TestSelector(req *AttestationRequest, options *TestSelectorOpti
 			reqErrors = append(reqErrors, err)
 		}
 
-		return nil, reqErrors
+		// all requests have failed
+		if len(reqErrors) == numServices {
+			return nil, reqErrors
+		}
 	}
 
 	var result []*TestSelectorResponse

--- a/notarize.go
+++ b/notarize.go
@@ -432,7 +432,7 @@ func (c *Client) createAttestation(ctx context.Context, req *AttestationRequest)
 
 func (c *Client) handleAttestations(attestations []*AttestationResponse, options *NotarizationOptions) error {
 	// can't do time deviation and integrity checks with only one attestation
-	if len(attestations) < 1 {
+	if len(attestations) < 2 {
 		return nil
 	}
 

--- a/notarize.go
+++ b/notarize.go
@@ -413,7 +413,10 @@ func (c *Client) createAttestation(ctx context.Context, req *AttestationRequest)
 			reqErrors = append(reqErrors, err)
 		}
 
-		return nil, reqErrors
+		// all requests have failed
+		if len(reqErrors) == len(c.notarizer) {
+			return nil, reqErrors
+		}
 	}
 
 	var result []*AttestationResponse

--- a/notarize.go
+++ b/notarize.go
@@ -41,7 +41,6 @@ import (
 	"fmt"
 	"net/http"
 	"slices"
-	"strings"
 	"sync"
 )
 
@@ -472,8 +471,8 @@ type verifyRequest struct {
 	Reports []*AttestationResponse `json:"reports"`
 }
 type verifyResponse struct {
-	ValidReports  []int    `json:"validReports"`
-	ErrorMessages []string `json:"errorMessages"`
+	ValidReports []int  `json:"validReports"`
+	ErrorMessage string `json:"errorMessage"`
 }
 
 func (c *Client) verifyReports(ctx context.Context, attestations []*AttestationResponse) ([]*AttestationResponse, error) {
@@ -510,8 +509,7 @@ func (c *Client) verifyReports(ctx context.Context, attestations []*AttestationR
 	result := <-resChan
 
 	if len(result.ValidReports) == 0 {
-		combinedErrMessage := strings.Join(result.ErrorMessages, "; ")
-		return nil, errors.New(combinedErrMessage)
+		return nil, errors.New(result.ErrorMessage)
 	}
 
 	var validAttestations []*AttestationResponse

--- a/random.go
+++ b/random.go
@@ -94,12 +94,12 @@ func (c *Client) GetAttestedRandom(max *big.Int, options *NotarizationOptions) (
 		options.VerificationContext = ctx
 	}
 
-	err = c.verifyReports(options.VerificationContext, attestations)
+	validAttestations, err := c.verifyReports(options.VerificationContext, attestations)
 	if err != nil {
 		return nil, []error{fmt.Errorf("attestation report verification failed: %w", err)}
 	}
 
 	c.logger.Println("Attestations verified by", getFullAddress("", nil, c.verifier, nil))
 
-	return attestations, nil
+	return validAttestations, nil
 }

--- a/random.go
+++ b/random.go
@@ -63,13 +63,16 @@ func (c *Client) GetAttestedRandom(max *big.Int, options *NotarizationOptions) (
 
 	// one or more of the requests have failed
 	if len(errChan) > 0 {
-		var errs []error
+		var reqErrors []error
 		for err := range errChan {
-			errs = append(errs, err)
+			reqErrors = append(reqErrors, err)
 			c.logger.Println("failed to create attestation:", err)
 		}
 
-		return nil, errs
+		// all request have failed
+		if len(reqErrors) == numServices {
+			return nil, reqErrors
+		}
 	}
 
 	var attestations []*AttestationResponse


### PR DESCRIPTION
Return all reports that were successfully created instead of throwing an error if one of the backends has not responded due to networking issues (one successful reply is enough when multiple backends are used)